### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ process.on('exit', function onExit() {
     pool.end();
 });
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var log = require('ssi-logger');
 var hbs = require('hbs');
 var paginate = require('handlebars-paginate');

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "jquery": "^2.2.3",
     "morgan": "^1.7.0",
     "mysql": "^2.10.2",
-    "node-uuid": "^1.4.7",
     "serve-favicon": "^2.3.0",
-    "ssi-logger": "^2.3.1"
+    "ssi-logger": "^2.3.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "casperjs": "^1.1.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.